### PR TITLE
ingest pre-built chdman bins from previous image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,15 +92,21 @@ LABEL maintainer="thelamer"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    curl \
     file \
+    flac \
     go-ipfs \
     nginx \
     nodejs \
     p7zip \
-    python3 && \
+    python3 \
+    sdl2 && \
   mkdir /data && \
-  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    mame-tools && \
+  echo "**** grab pre-built chdman ****" && \
+  curl -L \
+    "https://ipfs.infura.io/ipfs/QmUfYfuoxPgDRc9Mniv1TBXv6LXPRNArAabZo5VnzfZNtP" \
+    -o /usr/local/bin/chdman && \
+  chmod +x /usr/local/bin/chdman && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -91,16 +91,22 @@ LABEL maintainer="thelamer"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    curl \
     file \
+    flac \
     nginx \
     nodejs \
     p7zip \
-    python3 && \
+    python3 \
+    sdl2 && \
   mkdir /data && \
-  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    mame-tools && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/community \
     go-ipfs && \
+  echo "**** grab pre-built chdman ****" && \
+  curl -L \
+    "https://ipfs.infura.io/ipfs/QmUqmGm5KUeeWSS9FG9DMuSQPpvU7RqffFR9n3rJXDQ8AQ" \
+    -o /usr/local/bin/chdman && \
+  chmod +x /usr/local/bin/chdman && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -92,15 +92,21 @@ LABEL maintainer="thelamer"
 RUN \
   echo "**** install runtime packages ****" && \
   apk add --no-cache \
+    curl \
     file \
+    flac \
     go-ipfs \
     nginx \
     nodejs \
     p7zip \
-    python3 && \
+    python3 \
+    sdl2 && \
   mkdir /data && \
-  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    mame-tools && \
+  echo "**** grab pre-built chdman ****" && \
+  curl -L \
+    "https://ipfs.infura.io/ipfs/QmPYV2qJi3QrgqS9gPbX4XQ7DoNj3aZAz9sHy2Bo3Xeqbj" \
+    -o /usr/local/bin/chdman && \
+  chmod +x /usr/local/bin/chdman && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **04.04.22:** - Ingest pre-built chdman bins during build time.
 * **23.02.22:** - Update ingestion point for emulatorjs bins.
 * **25.01.22:** - Allow users to mount in existing rom directories.
 * **14.01.22:** - Add profile paths and rebase to Alpine 3.15.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,6 +91,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "04.04.22:", desc: "Ingest pre-built chdman bins during build time." }
   - { date: "23.02.22:", desc: "Update ingestion point for emulatorjs bins." }
   - { date: "25.01.22:", desc: "Allow users to mount in existing rom directories." }
   - { date: "14.01.22:", desc: "Add profile paths and rebase to Alpine 3.15." }


### PR DESCRIPTION
Closes #21 

Need to use bins from the previous image as edge is now out of sync enough with 3.15 to bork out bins. 

Tested with a local install. 