### PR TITLE
#62 symlink in a new /roms path if the user is mounting in paths RO

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ Mobile browsers will function, just keep in mind compatibility will be reduced e
 
 **This container (outside of the profile functionality) only generates a static set of files that can be hosted on any web provider even object storage. Eveyrthing runs in the clients browser and there are no dependencies on this container. To extract/copy this website it is at the path `/emulatorjs/frontend` inside the container. If you are happy with the catalouge you have created and no longer want to run stuff like the IPFS backend or want to upload these files to some other hosting provider you can simply copy the contents of that directory and kill off this container. This container can also be started without IPFS once you collection is set using the environment variable `-e DISABLE_IPFS=true`.**
 
-Mounting in existing rom directories can be achieved by pointing to the default folder structure, IE lets say you would like to mount your NES library:
+**Mounting in existing rom directories Read Only can be achieved by using a special root path `/roms`, For example for NES:**
 
-`-v /path/to/nes/roms:/data/nes/roms`
+`-v /path/to/nes/roms:/roms/nes:ro`
 
-The folder names are:
+The folder names for systems are:
 * 3do
 * arcade
 * atari2600
@@ -334,6 +334,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **23.01.24:** - Add logic to symlink out RO rom directories to support upgrades.
 * **14.01.24:** - Update remaining cores for melonds and yabause threaded to fix audio issues.
 * **11.01.24:** - Use Node 16 on x86 image to restore metadata uploads in backend, update psx core to current.
 * **07.01.24:** - Update to use new Mupen64 plus core by default.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,11 +51,11 @@ app_setup_block: |
 
   **This container (outside of the profile functionality) only generates a static set of files that can be hosted on any web provider even object storage. Eveyrthing runs in the clients browser and there are no dependencies on this container. To extract/copy this website it is at the path `/emulatorjs/frontend` inside the container. If you are happy with the catalouge you have created and no longer want to run stuff like the IPFS backend or want to upload these files to some other hosting provider you can simply copy the contents of that directory and kill off this container. This container can also be started without IPFS once you collection is set using the environment variable `-e DISABLE_IPFS=true`.**
 
-  Mounting in existing rom directories can be achieved by pointing to the default folder structure, IE lets say you would like to mount your NES library:
+  **Mounting in existing rom directories Read Only can be achieved by using a special root path `/roms`, For example for NES:**
 
-  `-v /path/to/nes/roms:/data/nes/roms`
+  `-v /path/to/nes/roms:/roms/nes:ro`
 
-  The folder names are:
+  The folder names for systems are:
   * 3do
   * arcade
   * atari2600
@@ -86,8 +86,10 @@ app_setup_block: |
   * vb
   * vectrex
   * ws
+
 # changelog
 changelogs:
+  - {date: "23.01.24:", desc: "Add logic to symlink out RO rom directories to support upgrades."}
   - {date: "14.01.24:", desc: "Update remaining cores for melonds and yabause threaded to fix audio issues."}
   - {date: "11.01.24:", desc: "Use Node 16 on x86 image to restore metadata uploads in backend, update psx core to current."}
   - {date: "07.01.24:", desc: "Update to use new Mupen64 plus core by default."}

--- a/root/etc/s6-overlay/s6-rc.d/init-emulatorjs-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-emulatorjs-config/run
@@ -40,13 +40,12 @@ cp /defaults/mime.types /etc/nginx/mime.types
 # nginx body cache
 lsiown -R abc:root /var/lib/nginx
 
-# allow users to mount in rom dirs
+# allow users to mount in ro rom dirs
 DIRS='3do atari2600 atari7800 colecovision doom gba lynx n64 nes odyssey2 psx segaCD segaMD segaSaturn snes vb ws arcade atari5200 gb gbc jaguar msx nds ngp pce sega32x segaGG segaMS segaSG vectrex'
 for DIR in ${DIRS}; do
-    if [[ -d "/data/${DIR}" ]]; then
-        lsiown abc:abc "/data/${DIR}"
-    fi
-    if [[ -d "/data/${DIR}/roms" ]]; then
-        lsiown abc:abc "/data/${DIR}/roms"
+    if [[ -d "/roms/${DIR}" ]] && [[ ! -L "/data/${DIR}/roms" ]]; then
+        mkdir -p /data/${DIR}
+        ln -s /roms/${DIR} /data/${DIR}/roms
+        lsiown abc:abc /data/${DIR}
     fi
 done


### PR DESCRIPTION
Testing through different methods I did not want to break anyones setup unless they are already using ro paths. 
This is the most unobtrusive method I could think of. 
Looks for a new path /roms/xxx and symlinks them on init. 