### PR TITLE
use pinned node for both amd64 and aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,11 +132,12 @@ RUN \
     sdl2 && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
     mame-tools && \
+  mkdir /data && \
   echo "**** use pinned node ****" && \
   curl -L \
-    https://unofficial-builds.nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64-musl.tar.gz \
-    | tar -xz --strip-components=1 -C / && \
-  mkdir /data && \
+    https://github.com/thelamer/node-stash/raw/master/v16.20.2/x86_64/node -o \
+    /bin/node && \
+  chmod +x /bin/node && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -131,13 +131,17 @@ RUN \
     flac \
     kubo \
     nginx \
-    nodejs \
     p7zip \
     python3 \
     sdl2 && \
   mkdir /data && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
     mame-tools && \
+  echo "**** use pinned node ****" && \
+  curl -L \
+    https://github.com/thelamer/node-stash/raw/master/v16.20.2/aarch64/node -o \
+    /bin/node && \
+  chmod +x /bin/node && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.01.24:** - Pin node back on aarch64 as well for compatibility.
 * **23.01.24:** - Add logic to symlink out RO rom directories to support upgrades.
 * **14.01.24:** - Update remaining cores for melonds and yabause threaded to fix audio issues.
 * **11.01.24:** - Use Node 16 on x86 image to restore metadata uploads in backend, update psx core to current.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -89,6 +89,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - {date: "24.01.24:", desc: "Pin node back on aarch64 as well for compatibility."}
   - {date: "23.01.24:", desc: "Add logic to symlink out RO rom directories to support upgrades."}
   - {date: "14.01.24:", desc: "Update remaining cores for melonds and yabause threaded to fix audio issues."}
   - {date: "11.01.24:", desc: "Use Node 16 on x86 image to restore metadata uploads in backend, update psx core to current."}


### PR DESCRIPTION
Tested this on one of my builders it is the aarch64 node from their docker image for Musl. 